### PR TITLE
:bug: fix clean-all

### DIFF
--- a/abstract-machine/Makefile
+++ b/abstract-machine/Makefile
@@ -156,5 +156,6 @@ clean:
 CLEAN_ALL = $(dir $(shell find . -mindepth 2 -name Makefile))
 clean-all: $(CLEAN_ALL) clean
 $(CLEAN_ALL):
+	-@$(MAKE) -s -C $@ clean-all
 	-@$(MAKE) -s -C $@ clean
 .PHONY: clean-all $(CLEAN_ALL)


### PR DESCRIPTION
Fix ``make clean-all`` could't remove am/build and klib/build.